### PR TITLE
Add add-on for Primo VE for removing GES request

### DIFF
--- a/features.json
+++ b/features.json
@@ -71,5 +71,24 @@
 		"npmid": "primo-explore-app-store-feature-demo-b",
 		"version": "0.0.5",
 		"hook": "prm-search-bar-after"
+	},
+	{
+	    "face": "https://avatars2.githubusercontent.com/u/19833254?s=400&v=4",
+	    "notes": "Allows you to remove the GES request from Primo VE full view. Except for the configured locations",
+	    "who": "Gilad Wolf",
+	    "what": "remove specific request except for location",
+	    "linkGit": "https://github.com/gilax/remove-specific-request-for-location",
+	    "npmid": "remove-specific-request-for-location",
+	    "hook": "prm-service-links-after",
+	    "version": "1.0.5",
+	    "systemExclusive": "ve",
+	    "config": {
+		"form":
+		    [
+			{"key":"libraryCode", "templateOptions":{"label": "library code for appearance"}},
+			{"key":"subLocationCode", "templateOptions":{"label": "location code for appearance"}},
+			{"key":"displayLabel", "templateOptions":{"label": "display link"}}
+		    ]
+	    }
 	}
 ]


### PR DESCRIPTION
This add-on will remove the configured GES request {{displayLabel}} from all the items in Full view. The request will still be available on Locations and Libraries that approved by {{libraryCode}} and {{subLocationCode}}. The places can single place or array with commas.

We added an option to the description that can filter the system (primo or VE) by the "systemExclusive" field.