### PR TITLE
bulib: add `-help-menu` and bugfix `-unpaywall`

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,5 +1,57 @@
 [
 	{
+		"face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
+		"notes": "Add popup Help Menu with trigger in the Primo Top Bar",
+		"who": "BU Libraries",
+		"what": "help-menu-topbar",
+		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
+		"npmid": "primo-explore-help-menu",
+		"version": "1.1.4",
+		"hook": "prm-search-bookmark-filter-after",
+		"config": {
+			"form": [
+				{
+					"key": "logToConsole",
+					"type": "select",
+					"defaultValue": false,
+					"templateOptions": {
+						"label": "(debug) Log debug messages to console",
+						"required": false,
+						"options": [
+							{ "name": "true",  "value": true  },
+							{ "name": "false", "value": false }
+						]
+					}
+				},
+				{
+					"key": "publishEvents",
+					"type": "select",
+					"defaultValue": false,
+					"templateOptions": {
+						"label": "(debug) Determine whether click/usage events are published to Analytics",
+						"required": false,
+						"options": [
+							{ "name": "true",  "value": true  },
+							{ "name": "false", "value": false }
+						]
+					}
+				},
+				{
+					"key": "helpMenuWidth",
+					"type": "input",
+					"defaultValue":500,
+					"templateOptions": {
+						"required": false,
+						"label": "Width of help-menu (nuber of pixels as an Integer)",
+						"placeholder": 500
+					}
+				},
+				{"key":"list_of_elements"},
+				{"key":"logEventToAnalytics"}
+			]
+		}
+	},
+	{
     "face": "https://avatars0.githubusercontent.com/u/5099608?s=200&v=4",
     "notes": "Add Third Iron powered enhancements to your search results: LibKey Instant PDF Downloading for fast content access, Viewing the Complete Issue of an article inside of BrowZine to increase serendipitous discovery and Journal Cover Images to improve journal recognition.",
     "who": "Third Iron, LLC",

--- a/features.json
+++ b/features.json
@@ -205,7 +205,7 @@
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
 		"npmid": "primo-explore-unpaywall",
 		"version": "1.1.7",
-		"hook": "prm-search-result-avaliability-line-after",
+		"hook": "prm-search-result-availability-line-after",
 		"config": {
 			"form": [
 				{


### PR DESCRIPTION

|package|version|description of changes|
|:-------:|:-------|:-----------------------|
|[`-help-menu`](/bulib/primo-explore-bu/tree/master/packages/help-menu)|[1.1.4](https://www.npmjs.com/package/primo-explore-help-menu/v/1.1.4)|add as a new "BU Libraries" package|
|[`-unpaywall`](/bulib/primo-explore-bu/tree/master/packages/unpaywall)|[1.1.7](https://www.npmjs.com/package/primo-explore-unpaywall/v/1.1.7)|fix the `hook` its added to|