### PR TITLE
bulib: [unpaywall] Update with collision protection, `overrideOACheck` option

### DIFF
--- a/features.json
+++ b/features.json
@@ -197,15 +197,15 @@
       ]
     }
   },
-{
+	{
 		"face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
 		"notes": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
 		"who": "BU Libraries",
 		"what": "bulib-unpaywall",
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
 		"npmid": "primo-explore-unpaywall",
-		"version": "1.1.7",
-		"hook": "prm-search-result-availability-line-after",
+		"version": "1.2.1",
+		"hook": "prm-search-result-availability-line",
 		"config": {
 			"form": [
 				{
@@ -224,8 +224,20 @@
 					"templateOptions": {
 						"required": false,
 						"label": "Include OA links on search results page",
+						"options":[
+							{ "name": "true",  "value": true  },
+							{ "name": "false", "value": false }
+						]
+					}
+				},
+				{
+					"key": "overrideOACheck",
+					"type": "select",
+					"defaultValue": false,
+					"templateOptions": {
+						"label": "(debug) Make unpaywall call regardless of OA status",
 						"options": [
-							{ "name": "true","value": true },
+							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
 					}
@@ -237,7 +249,7 @@
 					"templateOptions": {
 						"label": "Add version qualification to link display ('Submitted', 'Accepted')",
 						"options": [
-							{ "name": "true","value": true },
+							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
 					}
@@ -249,7 +261,7 @@
 					"templateOptions": {
 						"label": "(debug) Log debug messages to console",
 						"options": [
-							{ "name": "true","value": true },
+							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
 					}
@@ -261,7 +273,7 @@
 					"templateOptions": {
 						"label": "(debug) Display table of values from Item PNX",
 						"options": [
-							{ "name": "true","value": true },
+							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
 					}
@@ -273,7 +285,7 @@
 					"templateOptions": {
 						"label": "(debug) Determine whether events are published to Analytics",
 						"options": [
-							{ "name": "true","value": true },
+							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
 					}


### PR DESCRIPTION
### Background
- 'collision protection': @elizoller recently helped convert our app such that it will still work if you already have something in `prm-search-availability-line-after` (such as 'thirdiron's new `primo-explore-brozine` addon)
- `overrideOACheck` option: we check `item.pnx.addata.oa` before making the unpaywall call and are checking if there's something in `primostudio` that makes that get in the way (that and it's just potentially useful)

### Description of Changes
- update `version` from 1.1.7 -> 1.2.1
- add a new `overrideOACheck` variable to the configuration options