### PR TITLE
bulib: multiple version updates to 'help-menu' and 'unpaywall'

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,12 +1,12 @@
 [
 	{
 		"face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
-		"notes": "Add popup Help Menu with trigger in the Primo Top Bar",
+		"notes": "Embed a menu of custom help information in the top menu bar",
 		"who": "BU Libraries",
 		"what": "help-menu-topbar",
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
 		"npmid": "primo-explore-help-menu",
-		"version": "1.1.4",
+		"version": "1.2.2",
 		"hook": "prm-search-bookmark-filter-after",
 		"config": {
 			"form": [
@@ -34,6 +34,16 @@
 							{ "name": "true",  "value": true  },
 							{ "name": "false", "value": false }
 						]
+					}
+				},
+				{
+					"key": "helpMenuTitle",
+					"type": "input",
+					"defaultValue":"Search Help",
+					"templateOptions": {
+						"required": false,
+						"label": "Page and popup title displayed at the top of the menu (useful for translations)",
+						"placeholder": "Search Help"
 					}
 				},
 				{

--- a/features.json
+++ b/features.json
@@ -214,7 +214,7 @@
 		"what": "bulib-unpaywall",
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
 		"npmid": "primo-explore-unpaywall",
-		"version": "1.2.1",
+		"version": "1.3.2",
 		"hook": "prm-search-result-availability-line",
 		"config": {
 			"form": [
@@ -225,6 +225,33 @@
 						"required": true,
 						"label": "Email used for Unpaywall API access",
 						"placeholder": "username@institution.edu"
+					}
+				},
+				{
+					"key": "labelText",
+					"type": "input",
+					"templateOptions": {
+						"required": false,
+						"label": "Text/copy for the main call-to-action",
+						"placeholder": "Open Access available via unpaywall"
+					}
+				},
+				{
+					"key": "imageUrl",
+					"type": "input",
+					"templateOptions": {
+						"required": false,
+						"label": "Alternative image to display with unpaywall link",
+						"placeholder": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Open_Access_logo_PLoS_white.svg/384px-Open_Access_logo_PLoS_white.svg.png"
+					}
+				},
+				{
+					"key": "imageStyle",
+					"type": "input",
+					"templateOptions": {
+						"required": false,
+						"label": "CSS tweaking to style whatever image you've chosen",
+						"placeholder": "height: 24px; vertical-align: bottom; padding-right: 5px;"
 					}
 				},
 				{

--- a/features.json
+++ b/features.json
@@ -6,7 +6,7 @@
 		"what": "help-menu-topbar",
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/help-menu",
 		"npmid": "primo-explore-help-menu",
-		"version": "1.2.2",
+		"version": "1.3.0",
 		"hook": "prm-search-bookmark-filter-after",
 		"config": {
 			"form": [

--- a/features.json
+++ b/features.json
@@ -209,13 +209,13 @@
   },
 {
 		"face": "https://avatars2.githubusercontent.com/u/11337842?s=200&v=4",
-		"notes": "Add 'Open Access available via unpaywall' link to search-result-avaliability-line-after in Primo New UI",
+		"notes": "Add Open Access clickthrough link to search-result-avaliability-line via unpaywall",
 		"who": "BU Libraries",
 		"what": "bulib-unpaywall",
 		"linkGit": "https://github.com/bulib/primo-explore-bu/tree/master/packages/unpaywall",
 		"npmid": "primo-explore-unpaywall",
-		"version": "1.1.7",
-		"hook": "prm-search-result-availability-line-after",
+		"version": "1.2.1",
+		"hook": "prm-search-result-availability-line",
 		"config": {
 			"form": [
 				{
@@ -225,6 +225,19 @@
 						"required": true,
 						"label": "Email used for Unpaywall API access",
 						"placeholder": "username@institution.edu"
+					}
+				},
+				{
+					"key": "overrideOACheck",
+					"type": "select",
+					"defaultValue": true,
+					"templateOptions": {
+						"required": false,
+						"label": "Make unpaywall call regardless of OA status",
+						"options": [
+							{ "name": "true","value": true },
+							{ "name": "false", "value": false }
+						]
 					}
 				},
 				{


### PR DESCRIPTION
### Description of Changes
adjust the version, notes, and configuration options for 
- `primo-explore-unpaywall`: 
  - [`1.1.7` -> `1.2.1`](https://github.com/bulib/primo-explore-bu/pull/9): add `overrideOACheck` for debugging and troubleshooting
  - [`1.2.1` -> `1.3.2`](https://github.com/bulib/primo-explore-bu/pull/18): add three additional configurations for adjusting UI/UX display
- `primo-explore-help-menu`: 
  - [`1.1.4` -> `1.2.2`](https://github.com/bulib/primo-explore-bu/pull/16): add customizable title