### PR TITLE
fix: Yewno primo addon

### DIFF
--- a/features.json
+++ b/features.json
@@ -5,7 +5,7 @@
 		"who": "Yewno",
 		"what": "Yewno Primo Addon",
 		"linkGit": "https://github.com/yewno/primo-addon",
-		"npmid": "@yewno/primo-addon",
+		"npmid": "yewno-primo-addon",
 		"version": "0.0.6",
 		"hook": "prm-back-to-library-search-button-after",
 		"config": {


### PR DESCRIPTION
This PR updates the Yewno addon to `yewno-primo-addon` (from `@yewno/primo-addon`).  This new npm package resolves issues unearthed from the following feedback:

- https://github.com/primousers/primostudio/pull/61
- https://github.com/primousers/primostudio/pull/62