### PR TITLE
primo-explore-lod-author-card 

### DIFF
--- a/features.json
+++ b/features.json
@@ -808,6 +808,6 @@
 	  "linkGit": "https://github.com/jweisman/primo-explore-lod-author-card",
 	  "npmid": "primo-studio-lod-author-card",
 	  "version": "0.0.4",
-	  "hook": "prmFullViewAfter"
+	  "hook": "prm-full-view-after"
 	}
 ]

--- a/features.json
+++ b/features.json
@@ -799,5 +799,15 @@
 	      }
 	    ]
 	  }
-}
+        },
+	{
+	  "face": "https://avatars.githubusercontent.com/u/80420?s=60&u=1ca4b34fda800d52106c859b94f8c4d5959929bb&v=4",
+	  "notes": "Adds a widget in the Full View to display an author card based on Linked Data",
+	  "who": "Josh Weisman",
+	  "what": "Linked Data Author Card",
+	  "linkGit": "https://github.com/jweisman/primo-explore-lod-author-card",
+	  "npmid": "primo-studio-lod-author-card",
+	  "version": "0.0.4",
+	  "hook": "prmFullViewAfter"
+	}
 ]

--- a/features.json
+++ b/features.json
@@ -806,7 +806,7 @@
 	  "who": "Josh Weisman",
 	  "what": "Linked Data Author Card",
 	  "linkGit": "https://github.com/jweisman/primo-explore-lod-author-card",
-	  "npmid": "primo-studio-lod-author-card",
+	  "npmid": "primo-explore-lod-author-card",
 	  "version": "0.0.4",
 	  "hook": "prm-full-view-after"
 	}

--- a/features.json
+++ b/features.json
@@ -807,7 +807,7 @@
 	  "what": "Linked Data Author Card",
 	  "linkGit": "https://github.com/jweisman/primo-explore-lod-author-card",
 	  "npmid": "primo-explore-lod-author-card",
-	  "version": "0.0.4",
+	  "version": "0.0.5",
 	  "hook": "prm-full-view-after"
 	}
 ]

--- a/features.json
+++ b/features.json
@@ -807,7 +807,7 @@
 	  "what": "Linked Data Author Card",
 	  "linkGit": "https://github.com/jweisman/primo-explore-lod-author-card",
 	  "npmid": "primo-explore-lod-author-card",
-	  "version": "0.0.5",
+	  "version": "0.0.6",
 	  "hook": "prm-full-view-after"
 	}
 ]


### PR DESCRIPTION
The primo-explore-lod-author-card addon installs correctly in the interface for me, but the feature doesn't work. Does it work for anyone else?