### PR TITLE
Remove HahtiTrust plugin

### DIFF
--- a/features.json
+++ b/features.json
@@ -673,16 +673,6 @@
 		"hook": "prm-no-search-result-after"
 	},
 	{
-		"face": "https://avatars2.githubusercontent.com/u/5121409?s=200&v=4",
-		"notes": "When search results are displayed, a record's OCLC numbers are passed to the HathiTrust Bib API. If at least one item with free full-text access is found, a link to the HathiTrust record is appended to the availability section",
-		"who": "UMNLibraries",
-		"what": "primo-explore-hathitrust-availability",
-		"linkGit": "https://github.com/UMNLibraries/primo-explore-hathitrust-availability",
-		"npmid": "hathi-trust-availability-studio",
-		"version": "0.0.2",
-		"hook": "prm-search-result-availability-line-after"
-	},
-	{
 		"face": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQR63Hw5_KOSu46kUJhwJbxYFMbKxUsfIpwsKAq7gb99RD5pCK7",
 		"notes": "Slider input for range facet",
 		"who": "John Doe",


### PR DESCRIPTION
I suggest that we remove the HathiTrust option from Primo Studio. This package is based on an unmaintained private fork that does not work with VE. Given that most of the community is now on VE, the presence of this forked package seems to cause nothing but confusion. More info: https://github.com/UMNLibraries/primo-explore-hathitrust-availability/issues/13.